### PR TITLE
fix: [SNOW-2096443] Add variant type support for StructField.from_json

### DIFF
--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -1004,6 +1004,8 @@ def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
         elif _FIXED_VECTOR_PATTERN.match(json_value):
             m = _FIXED_VECTOR_PATTERN.match(json_value)
             return VectorType(m.group(1), int(m.group(2)))  # type: ignore[union-attr]
+        elif json_value == "variant":
+            return VariantType()
         else:
             raise ValueError(f"Cannot parse data type: {str(json_value)}")
     else:


### PR DESCRIPTION
`snowflake.snowpark.types.StructField.from_json` does not support `VariantType()`.  This adds support for `VariantType()`.

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2096443

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This adds a conditional to `_parse_datatype_json_value` to handle `VariantType()`
